### PR TITLE
Better typings for CommandBus & QueryBus

### DIFF
--- a/packages/query-bus/src/index.ts
+++ b/packages/query-bus/src/index.ts
@@ -12,14 +12,14 @@ export interface QueryHandler<TQuery extends Query<unknown>, TResult extends Que
   execute: (query: TQuery) => Promise<TResult>;
 }
 
-interface QueryHandlers {
-  [key: string]: QueryHandler<any, any>;
-}
+type ResultForQuery<TRegisteredQueryHandlers extends QueryHandler<any, any>[], TQuery extends Query<any>> = Promise<
+  ReturnType<Extract<TRegisteredQueryHandlers[number], { execute: (cmd: TQuery) => any }>["execute"]>
+>;
 
-export class QueryBus {
-  private availableHandlers: QueryHandlers;
+export class QueryBus<TRegisteredQueryHandlers extends QueryHandler<any, any>[]> {
+  private availableHandlers: Record<string, TRegisteredQueryHandlers[number]>;
 
-  constructor(queryHandlers: QueryHandler<any, any>[]) {
+  constructor(queryHandlers: TRegisteredQueryHandlers) {
     this.availableHandlers = {};
 
     queryHandlers.forEach((queryHandler) => {
@@ -27,7 +27,7 @@ export class QueryBus {
     }, this);
   }
 
-  public execute(query: Query<any>): Promise<QueryResult<any>> {
+  public execute<TQuery extends Query<any>>(query: TQuery): ResultForQuery<TRegisteredQueryHandlers, TQuery> {
     if (!this.availableHandlers[query.type]) {
       return Promise.reject(new Error(`Query: ${query.type} is not supported.`));
     }


### PR DESCRIPTION
This enables to provide type information about available command & query handlers, so command/query execution type can be nicely narrowed basing on the input argument. This shouldn't be breaking change as `any` is assumed by default as it was before.