### PR TITLE
feature/throw-on-failure-flag

### DIFF
--- a/packages/event-dispatcher/package.json
+++ b/packages/event-dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tshio/event-dispatcher",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/TheSoftwareHouse/node-common.git"

--- a/packages/event-dispatcher/src/index.ts
+++ b/packages/event-dispatcher/src/index.ts
@@ -55,14 +55,12 @@ export class EventDispatcher {
     this.logger.debug(`Dispatching event ${event.name}@${JSON.stringify(event.payload)}`);
 
     const promises = this.subscribers
-
-    if (!this.throwOnFailure){
-      promises
       .filter((s) => s.name === event.name)
       .map(({ subscriber }) =>
-        subscriber(event).catch((e) => this.logger.debug(`Subscriber failed to handle event ${event.name}`, e)),
+        this.throwOnFailure
+          ? subscriber(event)
+          : subscriber(event).catch((e) => this.logger.debug(`Subscriber failed to handle event ${event.name}`, e)),
       );
-    }
 
     await Promise.all(promises);
   }

--- a/packages/event-dispatcher/src/tests/event-dispatcher.spec.ts
+++ b/packages/event-dispatcher/src/tests/event-dispatcher.spec.ts
@@ -117,4 +117,24 @@ describe("event dispatcher", () => {
       })
       .finally(() => done());
   });
+
+  it("Error thrown by a Subscriber shouldn't be caught when throwOnFailure flag is set to true", (done) => {
+    const dispatcher = new EventDispatcher(logger, [], true);
+
+    dispatcher.addSubscriber(stubSubscriber);
+
+    dispatcher.subscribe("test", async () => {
+      await delay(10);
+      throw new Error("SomethingBadHappend");
+    });
+
+    dispatcher
+      .dispatch({
+        name: "test",
+        payload: { foo: 1 },
+      })
+      .catch(() => {
+        done();
+      });
+  });
 });


### PR DESCRIPTION
This PR adds throwOnFailure flag to event-dispatcher. It allows to pass errors through instead of catching them.